### PR TITLE
Alteração do Regex para replace somente com pontos e hífens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ $ yarn add validator-brazil
 ```js
 import { isCnpj, isCpf } from "validator-brazil";
 
-console.log(isCnpj("00111222000100"));
-console.log(isCpf("12312345600"));
+// No points or hyphens
+console.log(isCnpj("54334068000136")); // true
+console.log(isCnpj("00111222000100")); // false
+console.log(isCpf("29018170097")); // false
+console.log(isCpf("12312345600")); // false
+
+// With points or hyphens
+console.log(isCnpj("54.334.068/0001-36")); // true
+console.log(isCpf("123.123.456-00")); // false
 ```
 
 #### How to use with ES5
@@ -32,6 +39,13 @@ console.log(isCpf("12312345600"));
 ```js
 const validator = require("validator-brazil");
 
-console.log(validator.isCnpj("00111222000100"));
-console.log(validator.isCpf("12312345600"));
+// No points or hyphens
+console.log(validator.isCnpj("54334068000136")); // true
+console.log(validator.isCnpj("00111222000100")); // false
+console.log(validator.isCpf("29018170097")); // true
+console.log(validator.isCpf("12312345600")); // false
+
+// With points or hyphens
+console.log(validator.isCnpj("54.334.068/0001-36")); // true
+console.log(validator.isCpf("123.123.456-00")); // false
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validator-brazil",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "validacao de cpf e cnpj",
   "main": "lib/index.js",
   "types": "src/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
+const regex = /[\.\-\/]+/g;
+
 export const isCnpj = cnpj => {
-  cnpj = cnpj.replace(/[^\d]+/g, "");
+  cnpj = cnpj.replace(regex, "");
 
   if (cnpj == "") return false;
 
@@ -46,7 +48,8 @@ export const isCnpj = cnpj => {
 };
 
 export const isCpf = cpf => {
-  cpf = cpf.replace(/[^\d]+/g, "");
+  cpf = cpf.replace(regex, "");
+
   if (cpf == "") return false;
 
   if (


### PR DESCRIPTION
Desta forma não será possível validar CPF ou CNPJ com letras entre os dígitos numéricos.