### PR TITLE
Geração de CPF e CNPJ randômicos e refatoração de arquivos

### DIFF
--- a/src/cep.js
+++ b/src/cep.js
@@ -1,0 +1,11 @@
+var utils = require('./utils');
+
+function validate(cep) {
+  cep = cep.replace(utils.replace_regex, "");
+  var cepRegex = /^[0-9]{8}$/g;
+  return cepRegex.test(cep);
+}
+
+module.exports = {
+  validate,
+};

--- a/src/cnpj.js
+++ b/src/cnpj.js
@@ -1,0 +1,59 @@
+var utils = require('./utils');
+
+function validate(cnpj) {
+  cnpj = cnpj.replace(utils.replace_regex, "");
+
+  if (cnpj.length != 14) return false;
+
+  if (
+    cnpj == "00000000000000" ||
+    cnpj == "11111111111111" ||
+    cnpj == "22222222222222" ||
+    cnpj == "33333333333333" ||
+    cnpj == "44444444444444" ||
+    cnpj == "55555555555555" ||
+    cnpj == "66666666666666" ||
+    cnpj == "77777777777777" ||
+    cnpj == "88888888888888" ||
+    cnpj == "99999999999999"
+  )
+    return false;
+
+  var size = cnpj.length - 2;
+  var numbers = cnpj.substring(0, size);
+  var digits = cnpj.substring(size);
+  var sum = 0;
+  var pos = size - 7;
+  for (var i = size; i >= 1; i--) {
+    sum += numbers.charAt(size - i) * pos--;
+    if (pos < 2) pos = 9;
+  }
+  var result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
+  if (result != digits.charAt(0)) return false;
+
+  size = size + 1;
+  numbers = cnpj.substring(0, size);
+  sum = 0;
+  pos = size - 7;
+  for (var i = size; i >= 1; i--) {
+    sum += numbers.charAt(size - i) * pos--;
+    if (pos < 2) pos = 9;
+  }
+  result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
+  if (result != digits.charAt(1)) return false;
+
+  return true;
+}
+
+function generate() {
+  var base = utils.random_base(8);
+  var body = base + "0001";
+  var d1 = utils.digit('cnpj')("0" + body);
+  var d2 = utils.digit('cnpj')(body + d1);
+  return body + d1 + d2;
+}
+
+module.exports = {
+  validate,
+  generate,
+};

--- a/src/cpf.js
+++ b/src/cpf.js
@@ -1,0 +1,46 @@
+var utils = require('./utils');
+
+function validate(cpf) {
+  cpf = cpf.replace(utils.replace_regex, "");
+
+  if (
+    cpf.length != 11 ||
+    cpf == "00000000000" ||
+    cpf == "11111111111" ||
+    cpf == "22222222222" ||
+    cpf == "33333333333" ||
+    cpf == "44444444444" ||
+    cpf == "55555555555" ||
+    cpf == "66666666666" ||
+    cpf == "77777777777" ||
+    cpf == "88888888888" ||
+    cpf == "99999999999"
+  )
+    return false;
+
+  var add = 0;
+  for (var i = 0; i < 9; i++) add += parseInt(cpf.charAt(i)) * (10 - i);
+  var rev = 11 - (add % 11);
+  if (rev == 10 || rev == 11) rev = 0;
+  if (rev != parseInt(cpf.charAt(9))) return false;
+
+  add = 0;
+
+  for (var i = 0; i < 10; i++) add += parseInt(cpf.charAt(i)) * (11 - i);
+  rev = 11 - (add % 11);
+  if (rev == 10 || rev == 11) rev = 0;
+  if (rev != parseInt(cpf.charAt(10))) return false;
+  return true;
+}
+
+function generate() {
+  var base = utils.random_base(9);
+  var d1 = utils.digit("cpf1")(base);
+  var d2 = utils.digit("cpf2")(base + d1);
+  return base + d1 + d2;
+}
+
+module.exports = {
+  validate,
+  generate,
+};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,17 +1,33 @@
-/**
- * Retorna true se o CNPJ estiver válido
- * @param cnpj Cadastro Nacional da Pessoa Jurídica
- */
-export function isCnpj(cnpj: string): boolean;
+export namespace cnpj {
+  /**
+   * Retorna true se o CNPJ estiver válido
+   * @param cnpj Cadastro Nacional da Pessoa Jurídica
+   */
+  export function validate(cnpj: string): boolean;
 
-/**
- * Retorna true se o CPF estiver válido
- * @param cpf Cadastro de Pessoas Físicas
- */
-export function isCpf(cpf: string): boolean;
+  /**
+   * Retorna um CNPJ válido
+   */
+  export function generate(): string;
+}
 
-/**
- * Retorna true se o CEP estiver válido
- * @param cep Código de Endereçamento Postal
- */
-export function isCep(cep: string): boolean;
+export namespace cpf {
+  /**
+   * Retorna true se o CNPJ estiver válido
+   * @param cpf Cadastro de Pessoa Física
+   */
+  export function validate(cpf: string): boolean;
+
+  /**
+   * Retorna um CPF válido
+   */
+  export function generate(): string;
+}
+
+export namespace cep {
+  /**
+   * Retorna true se o CEP estiver válido
+   * @param cep Código de Endereçamento Postal
+   */
+  export function validate(cep: string): boolean;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,89 +1,9 @@
-var regex = /[\.\-\/]+/g;
+var cnpj = require("./cnpj");
+var cpf = require("./cpf");
+var cep = require("./cep");
 
-module.exports.isCnpj = function(cnpj) {
-  cnpj = cnpj.replace(regex, "");
-
-  if (cnpj == "") return false;
-
-  if (cnpj.length != 14) return false;
-
-  if (
-    cnpj == "00000000000000" ||
-    cnpj == "11111111111111" ||
-    cnpj == "22222222222222" ||
-    cnpj == "33333333333333" ||
-    cnpj == "44444444444444" ||
-    cnpj == "55555555555555" ||
-    cnpj == "66666666666666" ||
-    cnpj == "77777777777777" ||
-    cnpj == "88888888888888" ||
-    cnpj == "99999999999999"
-  )
-    return false;
-
-  var size = cnpj.length - 2;
-  var numbers = cnpj.substring(0, size);
-  var digits = cnpj.substring(size);
-  var sum = 0;
-  var pos = size - 7;
-  for (var i = size; i >= 1; i--) {
-    sum += numbers.charAt(size - i) * pos--;
-    if (pos < 2) pos = 9;
-  }
-  var result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
-  if (result != digits.charAt(0)) return false;
-
-  size = size + 1;
-  numbers = cnpj.substring(0, size);
-  sum = 0;
-  pos = size - 7;
-  for (var i = size; i >= 1; i--) {
-    sum += numbers.charAt(size - i) * pos--;
-    if (pos < 2) pos = 9;
-  }
-  result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
-  if (result != digits.charAt(1)) return false;
-
-  return true;
-};
-
-module.exports.isCpf = function(cpf) {
-  cpf = cpf.replace(regex, "");
-
-  if (cpf == "") return false;
-
-  if (
-    cpf.length != 11 ||
-    cpf == "00000000000" ||
-    cpf == "11111111111" ||
-    cpf == "22222222222" ||
-    cpf == "33333333333" ||
-    cpf == "44444444444" ||
-    cpf == "55555555555" ||
-    cpf == "66666666666" ||
-    cpf == "77777777777" ||
-    cpf == "88888888888" ||
-    cpf == "99999999999"
-  )
-    return false;
-
-  var add = 0;
-  for (var i = 0; i < 9; i++) add += parseInt(cpf.charAt(i)) * (10 - i);
-  var rev = 11 - (add % 11);
-  if (rev == 10 || rev == 11) rev = 0;
-  if (rev != parseInt(cpf.charAt(9))) return false;
-
-  add = 0;
-
-  for (var i = 0; i < 10; i++) add += parseInt(cpf.charAt(i)) * (11 - i);
-  rev = 11 - (add % 11);
-  if (rev == 10 || rev == 11) rev = 0;
-  if (rev != parseInt(cpf.charAt(10))) return false;
-  return true;
-};
-
-module.exports.isCep = function(cep) {
-  cep = cep.replace(regex, "");
-  var cepRegex = /^[0-9]{8}$/g;
-  return cepRegex.test(cep);
+module.exports = {
+  cnpj,
+  cep,
+  cpf,
 };

--- a/src/tests/cep.spec.js
+++ b/src/tests/cep.spec.js
@@ -1,23 +1,25 @@
-const isCep = require("../index").isCep;
+const cep = require("../cep");
 
-describe("cep validation", () => {
-  it("should return true to valid cep without hyphen", () => {
-    expect(isCep("14710130")).toBeTruthy();
-  });
-
-  it("should return true to invalid cep with 0 in the initial", () => {
-    expect(isCep("04710130")).toBeTruthy();
-  });
-
-  it("should return true to valid cep WITH hyphen", () => {
-    expect(isCep("54710-130")).toBeTruthy();
-  });
-
-  it("should return true to valid cep WITHOUT hyphen", () => {
-    expect(isCep("54710130")).toBeTruthy();
-  });
-
-  it("should return false to invalid cep", () => {
-    expect(isCep("5471012023")).toBeFalsy()
+describe("cep", () => {
+  describe('validate', () => {
+    it("should return true to valid cep without hyphen", () => {
+      expect(cep.validate("14710130")).toBeTruthy();
+    });
+  
+    it("should return true to invalid cep with 0 in the initial", () => {
+      expect(cep.validate("04710130")).toBeTruthy();
+    });
+  
+    it("should return true to valid cep WITH hyphen", () => {
+      expect(cep.validate("54710-130")).toBeTruthy();
+    });
+  
+    it("should return true to valid cep WITHOUT hyphen", () => {
+      expect(cep.validate("54710130")).toBeTruthy();
+    });
+  
+    it("should return false to invalid cep", () => {
+      expect(cep.validate("5471012023")).toBeFalsy()
+    });
   });
 });

--- a/src/tests/cnpj.spec.js
+++ b/src/tests/cnpj.spec.js
@@ -1,23 +1,33 @@
-const isCnpj = require("../index").isCnpj;
+const cnpj = require("../cnpj");
 
-describe("cnpj validation", () => {
-  it("should return true to valid cnpj without hyphen and points", () => {
-    expect(isCnpj("00933180000164")).toBeTruthy();
+describe("cnpj", () => {
+  describe('validate', () => {
+    it("should return true to valid cnpj without hyphen and points", () => {
+      expect(cnpj.validate("00933180000164")).toBeTruthy();
+    });
+  
+    it("should return true to valid cnpj with hyphen and points", () => {
+      expect(cnpj.validate("00.933.180/0001-64")).toBeTruthy();
+    });
+  
+    it("should return false with letters", () => {
+      expect(cnpj.validate("00933180000164a")).toBeFalsy();
+    });
+  
+    it("should return false to invalid cnpj with hyphen and points", () => {
+      expect(cnpj.validate("001112220000133")).toBeFalsy();
+    });
+  
+    it("should return false to invalid cnpj", () => {
+      expect(cnpj.validate("00000000000000")).toBeFalsy();
+    });
   });
 
-  it("should return true to valid cnpj with hyphen and points", () => {
-    expect(isCnpj("00.933.180/0001-64")).toBeTruthy();
-  });
-
-  it("should return false with letters", () => {
-    expect(isCnpj("00933180000164a")).toBeFalsy();
-  });
-
-  it("should return false to invalid cnpj with hyphen and points", () => {
-    expect(isCnpj("001112220000133")).toBeFalsy();
-  });
-
-  it("should return false to invalid cnpj", () => {
-    expect(isCnpj("00000000000000")).toBeFalsy();
+  describe('random', () => {
+    it('should create a random cnpj valid', () => {
+      expect(cnpj.validate(cnpj.generate())).toBeTruthy();
+      expect(cnpj.validate(cnpj.generate())).toBeTruthy();
+      expect(cnpj.validate(cnpj.generate())).toBeTruthy();
+    });
   });
 });

--- a/src/tests/cpf.spec.js
+++ b/src/tests/cpf.spec.js
@@ -1,23 +1,33 @@
-const isCpf = require("../index").isCpf;
+const cpf = require("../cpf");
 
 describe("cpf validation", () => {
-  it("should return true to valid cpf wythout hyphen and points", () => {
-    expect(isCpf("14552586017")).toBeTruthy();
+  describe('validate', () => {
+    it("should return true to valid cpf wythout hyphen and points", () => {
+      expect(cpf.validate("14552586017")).toBeTruthy();
+    });
+  
+    it("should return true to valid cpf with hyphen and points", () => {
+      expect(cpf.validate("145.525.860-17")).toBeTruthy();
+    });
+  
+    it("should return false with letters", () => {
+      expect(cpf.validate("14552586017a")).toBeFalsy();
+    });
+  
+    it("should return false to invalid cpf wythout hyphen and points", () => {
+      expect(cpf.validate("00011122233")).toBeFalsy();
+    });
+  
+    it("should return false to invalid cpf with hyphen and points", () => {
+      expect(cpf.validate("000.111.222-33")).toBeFalsy();
+    });
   });
 
-  it("should return true to valid cpf with hyphen and points", () => {
-    expect(isCpf("145.525.860-17")).toBeTruthy();
-  });
-
-  it("should return false with letters", () => {
-    expect(isCpf("14552586017a")).toBeFalsy();
-  });
-
-  it("should return false to invalid cpf wythout hyphen and points", () => {
-    expect(isCpf("00011122233")).toBeFalsy();
-  });
-
-  it("should return false to invalid cpf with hyphen and points", () => {
-    expect(isCpf("000.111.222-33")).toBeFalsy();
+  describe('random', () => {
+    it('should create a random cpf valid', () => {
+      expect(cpf.validate(cpf.generate())).toBeTruthy();
+      expect(cpf.validate(cpf.generate())).toBeTruthy();
+      expect(cpf.validate(cpf.generate())).toBeTruthy();
+    });
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,34 @@
+var replace_regex = /[\.\-\/]+/g;
+var multipliers = {
+  cnpj: [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2],
+  cpf1: [10, 9, 8, 7, 6, 5, 4, 3, 2],
+  cpf2: [11, 10, 9, 8, 7, 6, 5, 4, 3, 2],
+};
+
+function random_base(n) {
+  var base = "";
+  for (var i = 0; i < n; i++) {
+    base += Math.round(Math.random() * 9);
+  }
+  return base;
+}
+
+function digit(type) {
+  var array_multipliers = multipliers[type];
+
+  return function digit(value) {
+    var values = value.split("");
+  
+    var d = 11 - (values.reduce(function (acc, cur, i) {
+      return acc + cur * array_multipliers[i];
+    }, 0) % 11);
+  
+    return d < 10 ? d : 0;
+  }
+}
+
+module.exports = {
+  random_base,
+  replace_regex,
+  digit,
+};


### PR DESCRIPTION
Neste PR estou adicionando um gerador de cpf e cnpj válidos.

Com esta nova função será possível gerar cpf's e cnpj's da seguinte forma.

```javascript
cpf.generate();
// ou
cnpj.generate();
```

Houve também uma mudança na estrutura de arquivos mudando a forma de `import` da lib.

```javascript
import { cpf, cnpj } from 'validator-brazil';

// valida um cpf qualquer
cpf.validate('11122233344');

// valida um cnpj qualquer
cnpj.validate('11122233344');
```