### PR TITLE
feat: add support for alphanumeric CNPJ validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,89 +1,9 @@
-var regex = /[\.\-\/]+/g;
+const { isCep } = require("./validators/cep");
+const { isCpf } = require("./validators/cpf");
+const { isCnpj } = require("./validators/cnpj");
 
-module.exports.isCnpj = function(cnpj) {
-  cnpj = cnpj.replace(regex, "");
-
-  if (cnpj == "") return false;
-
-  if (cnpj.length != 14) return false;
-
-  if (
-    cnpj == "00000000000000" ||
-    cnpj == "11111111111111" ||
-    cnpj == "22222222222222" ||
-    cnpj == "33333333333333" ||
-    cnpj == "44444444444444" ||
-    cnpj == "55555555555555" ||
-    cnpj == "66666666666666" ||
-    cnpj == "77777777777777" ||
-    cnpj == "88888888888888" ||
-    cnpj == "99999999999999"
-  )
-    return false;
-
-  var size = cnpj.length - 2;
-  var numbers = cnpj.substring(0, size);
-  var digits = cnpj.substring(size);
-  var sum = 0;
-  var pos = size - 7;
-  for (var i = size; i >= 1; i--) {
-    sum += numbers.charAt(size - i) * pos--;
-    if (pos < 2) pos = 9;
-  }
-  var result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
-  if (result != digits.charAt(0)) return false;
-
-  size = size + 1;
-  numbers = cnpj.substring(0, size);
-  sum = 0;
-  pos = size - 7;
-  for (var i = size; i >= 1; i--) {
-    sum += numbers.charAt(size - i) * pos--;
-    if (pos < 2) pos = 9;
-  }
-  result = sum % 11 < 2 ? 0 : 11 - (sum % 11);
-  if (result != digits.charAt(1)) return false;
-
-  return true;
-};
-
-module.exports.isCpf = function(cpf) {
-  cpf = cpf.replace(regex, "");
-
-  if (cpf == "") return false;
-
-  if (
-    cpf.length != 11 ||
-    cpf == "00000000000" ||
-    cpf == "11111111111" ||
-    cpf == "22222222222" ||
-    cpf == "33333333333" ||
-    cpf == "44444444444" ||
-    cpf == "55555555555" ||
-    cpf == "66666666666" ||
-    cpf == "77777777777" ||
-    cpf == "88888888888" ||
-    cpf == "99999999999"
-  )
-    return false;
-
-  var add = 0;
-  for (var i = 0; i < 9; i++) add += parseInt(cpf.charAt(i)) * (10 - i);
-  var rev = 11 - (add % 11);
-  if (rev == 10 || rev == 11) rev = 0;
-  if (rev != parseInt(cpf.charAt(9))) return false;
-
-  add = 0;
-
-  for (var i = 0; i < 10; i++) add += parseInt(cpf.charAt(i)) * (11 - i);
-  rev = 11 - (add % 11);
-  if (rev == 10 || rev == 11) rev = 0;
-  if (rev != parseInt(cpf.charAt(10))) return false;
-  return true;
-};
-
-module.exports.isCep = function(cep) {
-  cep = cep.replace(regex, "");
-  var cepRegex = /^[0-9]{8}$/g;
-  return cepRegex.test(cep);
+module.exports = {
+  isCep,
+  isCpf,
+  isCnpj
 };

--- a/src/tests/cnpj.spec.js
+++ b/src/tests/cnpj.spec.js
@@ -13,11 +13,70 @@ describe("cnpj validation", () => {
     expect(isCnpj("00933180000164a")).toBeFalsy();
   });
 
-  it("should return false to invalid cnpj with hyphen and points", () => {
+  it("should return false to invalid cnpj", () => {
     expect(isCnpj("001112220000133")).toBeFalsy();
   });
 
-  it("should return false to invalid cnpj", () => {
+  it("should return false to zeroed cnpj", () => {
     expect(isCnpj("00000000000000")).toBeFalsy();
+  });
+
+  it('should validate alphanumeric CNPJ', () => {
+    expect(isCnpj('RSLADC9P000163')).toBeTruthy();
+  });
+
+  it('should validate alphanumeric CNPJ with hyphen and points', () => {
+    expect(isCnpj('BZ.8RJ.STE/0001-08')).toBeTruthy();
+  });
+
+  it('should validate lowercase alphanumeric CNPJ', () => {
+    expect(isCnpj('bz.8rj.ste/0001-08')).toBeTruthy();
+  });
+
+  it('should invalidate wrong alphanumeric CNPJ', () => {
+    expect(isCnpj('A1BC234D56EF01')).toBeFalsy();
+  });
+
+  it('should invalidate CNPJ with invalid characters', () => {
+    expect(isCnpj('BZ@8RJ#STE/0001-08')).toBeFalsy();
+  });
+
+  it('should invalidate CNPJ with wrong length', () => {
+    expect(isCnpj('A1BC234D56EF2')).toBeFalsy(); // 13 chars
+  });
+
+  it('should invalidate CNPJ with wrong check digits', () => {
+    expect(isCnpj('RSLADC9P000100')).toBeFalsy();
+  });
+
+  it('should return false for null', () => {
+    expect(isCnpj(null)).toBeFalsy();
+  });
+
+  it('should return false for empty string', () => {
+    expect(isCnpj('')).toBeFalsy();
+  });
+
+  it('should invalidate repeated numeric sequences', () => {
+    expect(isCnpj('00000000000000')).toBeFalsy();
+    expect(isCnpj('11111111111111')).toBeFalsy();
+    expect(isCnpj('22222222222222')).toBeFalsy();
+    expect(isCnpj('99999999999999')).toBeFalsy();
+  });
+
+  it('should invalidate repeated alphanumeric sequences', () => {
+    expect(isCnpj('AAAAAAAAAAAAAA')).toBeFalsy();
+    expect(isCnpj('BBBBBBBBBBBBBB')).toBeFalsy();
+    expect(isCnpj('ZZZZZZZZZZZZZZ')).toBeFalsy();
+  });
+
+  it('should invalidate repeated sequences with mask', () => {
+    expect(isCnpj('AA.AAA.AAA/AAAA-AA')).toBeFalsy();
+    expect(isCnpj('11.111.111/1111-11')).toBeFalsy();
+  });
+
+  it('should invalidate CNPJ with repeated base', () => {
+    expect(isCnpj('AAAAAAAAAAAA12')).toBeFalsy();
+    expect(isCnpj('11111111111112')).toBeFalsy();
   });
 });

--- a/src/validators/cep.js
+++ b/src/validators/cep.js
@@ -1,0 +1,9 @@
+function isCep(cep) {
+  if (!cep) return false;
+
+  cep = cep.replace(/\D/g, "");
+
+  return /^[0-9]{8}$/.test(cep);
+}
+
+module.exports = { isCep };

--- a/src/validators/cnpj.js
+++ b/src/validators/cnpj.js
@@ -1,0 +1,72 @@
+// Supports both numeric and alphanumeric CNPJ formats
+// based on Receita Federal specification
+
+var BASE_LENGTH = 12;
+
+var REGEX_BASE = /^([A-Z\d]){12}$/;
+var REGEX_CNPJ = /^([A-Z\d]){12}(\d){2}$/;
+
+var MASK_CHARS_REGEX = /[./-]/g;
+var INVALID_CHARS_REGEX = /[^A-Z\d./-]/i;
+
+var ASCII_BASE = "0".charCodeAt(0);
+
+var DV_WEIGHTS = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+function removeMask(cnpj) {
+  return cnpj.replace(MASK_CHARS_REGEX, "");
+}
+
+function isRepeatedSequence(str) {
+  return /^([A-Z\d])\1+$/.test(str);
+}
+
+function calculateDV(cnpj) {
+  if (!cnpj) return null;
+  if (INVALID_CHARS_REGEX.test(cnpj)) return null;
+
+  var cleanCnpj = removeMask(cnpj);
+
+  if (!REGEX_BASE.test(cleanCnpj) || isRepeatedSequence(cleanCnpj)) {
+    return null;
+  }
+
+  var sumDV1 = 0;
+  var sumDV2 = 0;
+
+  for (var i = 0; i < BASE_LENGTH; i++) {
+    var asciiValue = cleanCnpj.charCodeAt(i) - ASCII_BASE;
+    sumDV1 += asciiValue * DV_WEIGHTS[i + 1];
+    sumDV2 += asciiValue * DV_WEIGHTS[i];
+  }
+
+  var dv1 = sumDV1 % 11 < 2 ? 0 : 11 - (sumDV1 % 11);
+  sumDV2 += dv1 * DV_WEIGHTS[BASE_LENGTH];
+  var dv2 = sumDV2 % 11 < 2 ? 0 : 11 - (sumDV2 % 11);
+
+  return dv1.toString() + dv2.toString();
+}
+
+function isCnpj(cnpj) {
+  if (!cnpj) return false;
+
+  cnpj = cnpj.toUpperCase();
+
+  if (INVALID_CHARS_REGEX.test(cnpj)) return false;
+
+  var cleanCnpj = removeMask(cnpj);
+
+  if (!REGEX_CNPJ.test(cleanCnpj) || isRepeatedSequence(cleanCnpj)) {
+    return false;
+  }
+
+  var providedDV = cleanCnpj.substring(BASE_LENGTH);
+  var base = cleanCnpj.substring(0, BASE_LENGTH);
+  var calculatedDV = calculateDV(base);
+
+  if (!calculatedDV) return false;
+
+  return providedDV === calculatedDV;
+}
+
+module.exports = { isCnpj };

--- a/src/validators/cpf.js
+++ b/src/validators/cpf.js
@@ -1,0 +1,40 @@
+function isCpf(cpf) {
+  if (!cpf) return false;
+
+  if (!/^[0-9.\-]+$/.test(cpf)) return false;
+
+  cpf = cpf.replace(/\D/g, "");
+
+  if (cpf == "") return false;
+
+  if (
+    cpf.length != 11 ||
+    cpf == "00000000000" ||
+    cpf == "11111111111" ||
+    cpf == "22222222222" ||
+    cpf == "33333333333" ||
+    cpf == "44444444444" ||
+    cpf == "55555555555" ||
+    cpf == "66666666666" ||
+    cpf == "77777777777" ||
+    cpf == "88888888888" ||
+    cpf == "99999999999"
+  )
+    return false;
+
+  var add = 0;
+  for (var i = 0; i < 9; i++) add += parseInt(cpf.charAt(i)) * (10 - i);
+  var rev = 11 - (add % 11);
+  if (rev == 10 || rev == 11) rev = 0;
+  if (rev != parseInt(cpf.charAt(9))) return false;
+
+  add = 0;
+
+  for (var i = 0; i < 10; i++) add += parseInt(cpf.charAt(i)) * (11 - i);
+  rev = 11 - (add % 11);
+  if (rev == 10 || rev == 11) rev = 0;
+  if (rev != parseInt(cpf.charAt(10))) return false;
+  return true;
+}
+
+module.exports = { isCpf };


### PR DESCRIPTION
## Resumo

Este PR adiciona suporte ao novo formato de CNPJ alfanumérico, conforme definido pela Receita Federal.

A lógica de validação foi atualizada para suportar:
- o formato numérico atual de CNPJ
- o novo formato alfanumérico

## Motivação

A Receita Federal introduziu um novo formato de CNPJ que permite caracteres alfanuméricos nas primeiras 12 posições, mantendo os 2 últimos dígitos como verificadores (DV).

Referência:
https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico

## Alterações

- Atualização da validação de CNPJ para suportar formato alfanumérico
- Manutenção da compatibilidade com CNPJ numérico
- Validação de caracteres inválidos
- Detecção de sequências repetidas (ex: `000...`, `AAA...`)
- Refatoração do código para melhorar legibilidade e padronização
- Expansão da cobertura de testes

## Testes

Foram adicionados testes cobrindo:

- CNPJ numérico válido (com e sem máscara)
- CNPJ alfanumérico válido (com e sem máscara)
- Suporte a entrada em lowercase
- Caracteres inválidos
- Tamanho inválido
- Dígitos verificadores inválidos
- Sequências repetidas (numéricas e alfanuméricas)
- Valores nulos e vazios

## Compatibilidade

A alteração é totalmente retrocompatível com a validação de CNPJ numérico existente.

## Observações

A implementação segue o algoritmo oficial disponibilizado pela Receita Federal, incluindo o cálculo de DV adaptado para o formato alfanumérico.